### PR TITLE
Override breakpoint for navbar collapse

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -125,3 +125,30 @@ table tr td {
 .dropdown-menu {
     min-width: unset;
 }
+
+
+@media(max-width:1200px)  {
+    .navbar-collapse.collapse {
+        display: none !important;
+    }
+
+    .navbar-collapse {
+        overflow-x: visible !important;
+    }
+
+    .navbar-collapse.in {
+        overflow-y: auto !important;
+    }
+
+    .collapse.in {
+        display: block !important;
+    }
+
+    .navbar-toggle {
+        display: block !important;
+    }
+
+    .navbar-header {
+        float: none !important;
+    }
+}


### PR DESCRIPTION
Hello!

I was exploring systemli website using relatively small tablet screen and realised that the header covers main content (see screenshot). I am not an expert in css & bootstrap, but I added some overrides and it works - instead of turning full menu into a burger at default 768px it breaks at 1200px, which is enough. Hope you'll find it useful.

<img width="962" alt="Before" src="https://user-images.githubusercontent.com/39785/87346408-ec8e6800-c551-11ea-886d-91a0a8abf9ce.png">

With the changes, same width:

<img width="962" alt="After" src="https://user-images.githubusercontent.com/39785/87346885-8eae5000-c552-11ea-8cbc-ab4c92957b52.png">