### PR TITLE
hinweis zu thunderbird+openpgp aktualisiert

### DIFF
--- a/src/service/mail.html
+++ b/src/service/mail.html
@@ -10,7 +10,7 @@ translation_id: a20ccbe9557775d06f0e75bbedb0f07a
 <p>Wir haben uns bewusst gegen eine offene Registrierung von E-Mail-Accounts entschieden. Damit möchten wir hauptsächlich vermeiden, dass der Dienst missbraucht wird.</p>
 
 
-<p>Um deine E-Mails vor dem Auslesen zu schützen, solltest du GPG verwenden. Am praktikabelsten ist hierbei eine Kombination aus Thunderbird <a href="https://wiki.systemli.org/howto/howto/thunderbird_systemli">(Einrichtungsanleitung im Wiki)</a> und <a href="https://www.thunderbird-mail.de/lexicon/entry/17-enigmail/">Enigmail</a>.</p>
+<p>Um deine E-Mails vor dem Auslesen zu schützen, solltest du sie mit OpenPGP verschlüsseln. Praktikabel ist hierfür Thunderbird <a href="https://wiki.systemli.org/howto/howto/thunderbird78_pgp">(Einrichtungsanleitung im Wiki)</a>.</p>
 <p>Zusätzlich kannst du deine E-Mails auch per Browser mit unserem <a href="https://mail.systemli.org">Web-Client</a> abrufen.</p>
 
 <p>


### PR DESCRIPTION
rip enigmail :cry: 
verlinkt zu aktueller anleitung um thunderbird 78 mit pgp einzurichten