### PR TITLE
matrix service page (de): add link to wiki page on bridges

### DIFF
--- a/content/english/service/matrix.md
+++ b/content/english/service/matrix.md
@@ -21,6 +21,7 @@ and open alternative to Signal and Slack.
   - ⚠️ Clients exist that do not support end-to-end encryption
 - Multi-Device-Support (Smartphone, Browser, Desktop)
 - Networking with people and groups on [other Matrix servers](https://matrix.org/) (Federation)
+- Bridges to other messaging services ([see the wiki article - german only](https://wiki.systemli.org/howto/matrix-bridges))
 - Only for systemli:
   - Messages are automatically deleted after 30 days
   - IP addresses are not stored

--- a/content/german/service/matrix.md
+++ b/content/german/service/matrix.md
@@ -21,6 +21,7 @@ Es ist eine freie und offene Alternative zu Signal und Slack.
   - ⚠️ Es existieren Clients die die Ende-zu-Ende-Verschlüsselung nicht unterstützen
 - Multi-Device-Support (Smartphone, Browser, Desktop)
 - Vernetzung mit Personen und Gruppen auf [anderen Matrix-Servern](https://matrix.org/) (Föderation)
+- Brücken zu anderen Messenger-Diensten ([siehe Wiki-Artikel](https://wiki.systemli.org/howto/matrix-bridges))
 - Nur bei Systemli:
   - Nachrichten werden nach 30 Tagen automatisch gelöscht
   - IP-Adressen werden nicht gespeichert


### PR DESCRIPTION
Adds note on bridges to other messaging services and link to related wiki page