### PR TITLE
meet service page: remove requirement for 'modern browser'

### DIFF
--- a/content/english/service/meet.md
+++ b/content/english/service/meet.md
@@ -26,5 +26,4 @@ links:
 
 ## Information
 
-- Modern browser required (Chromium or Chrome), Firefox and Safari still cause problems
 - Mobile Apps available, Android ([F-Droid](https://f-droid.org/de/packages/org.jitsi.meet/), [Play Store](https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=en)) and [iOS](https://itunes.apple.com/us/app/jitsi-meet/id1165103905)

--- a/content/german/service/meet.md
+++ b/content/german/service/meet.md
@@ -26,5 +26,4 @@ links:
 
 ## Hinweise
 
-- Moderner Browser erforderlich (Chromium oder Chrome), Firefox und Safari machen noch Probleme
 - Mobile Apps verfügbar, Android ([F-Droid](https://f-droid.org/de/packages/org.jitsi.meet/), [Play Store](https://play.google.com/store/apps/details?id=org.jitsi.meet&hl=en)) und [iOS](https://itunes.apple.com/us/app/jitsi-meet/id1165103905)


### PR DESCRIPTION
didn't check on safari but the requirement for chromium seems to be obsolete: https://jitsi.github.io/handbook/docs/user-guide/supported-browsers