### PR TITLE
Fixed dead URLs in matrix.md

### DIFF
--- a/content/english/service/matrix.md
+++ b/content/english/service/matrix.md
@@ -11,7 +11,7 @@ links:
         url: https://element.systemli.org
         text: Webclient
     privacy:
-        url: https://wiki.systemli.org/howto/matrix-privacy
+        url: https://wiki.systemli.org/howto/matrix/privacy
         text: "Notes on secure use of Matrix (german)"
 ---
 Matrix is a decentralized and end-to-end encrypted messenger service with good support for group chats. It is a free 
@@ -23,7 +23,7 @@ and open alternative to Signal and Slack.
   - ⚠️ Clients exist that do not support end-to-end encryption
 - Multi-Device-Support (Smartphone, Browser, Desktop)
 - Networking with people and groups on [other Matrix servers](https://matrix.org/) (Federation)
-- Bridges to other messaging services ([see the wiki article - german only](https://wiki.systemli.org/howto/matrix-bridges))
+- Bridges to other messaging services ([see the wiki article - german only](https://wiki.systemli.org/howto/matrix/bridges))
 - Only for systemli:
   - Messages are automatically deleted on the server after 30 days
   - IP addresses are not stored
@@ -48,7 +48,7 @@ to `matrix.systemli.org` (by default it is set to matrix.org). A good documentat
 
 ℹ️ Element uses end-to-end encryption by default.
 
-ℹ️ Despite encryption, Matrix accumulates some metadata. See the [notes on secure use](https://wiki.systemli.org/howto/matrix-privacy (german)) in our wiki.
+ℹ️ Despite encryption, Matrix accumulates some metadata. See the [notes on secure use](https://wiki.systemli.org/howto/matrix/privacy (german)) in our wiki.
 
 ℹ️ In addition to the client element we recommend, there are other clients for Matrix. Thereby it can happen that they do not have all features (including security relevant ones) built in. You should have a look at the
-[Features carefully](https://matrix.org/clients-matrix/) and consider which client you use.
+[Features carefully](https://matrix.org/ecosystem/clients/) and consider which client you use.

--- a/content/german/service/matrix.md
+++ b/content/german/service/matrix.md
@@ -11,7 +11,7 @@ links:
         url: https://element.systemli.org
         text: Webclient
     privacy:
-        url: https://wiki.systemli.org/howto/matrix-privacy
+        url: https://wiki.systemli.org/howto/matrix/privacy
         text: "Hinweise zur sicheren Nutzung von Matrix"
 ---
 Matrix ist ein dezentraler und Ende-zu-Ende verschlüsselter Messenger Dienst mit guter Unterstützung für Gruppenchats. 
@@ -23,7 +23,7 @@ Es ist eine freie und offene Alternative zu Signal und Slack.
   - ⚠️ Es existieren Clients die die Ende-zu-Ende-Verschlüsselung nicht unterstützen
 - Multi-Device-Support (Smartphone, Browser, Desktop)
 - Vernetzung mit Personen und Gruppen auf [anderen Matrix-Servern](https://matrix.org/) (Föderation)
-- Brücken zu anderen Messenger-Diensten ([siehe Wiki-Artikel](https://wiki.systemli.org/howto/matrix-bridges))
+- Brücken zu anderen Messenger-Diensten ([siehe Wiki-Artikel](https://wiki.systemli.org/howto/matrix/bridges))
 - Nur bei Systemli:
   - Nachrichten werden nach 30 Tagen automatisch auf dem Server gelöscht
   - IP-Adressen werden nicht gespeichert
@@ -48,8 +48,8 @@ Dokumentation des Clients [bietet die TU Dresden an](https://doc.matrix.tu-dresd
 
 ℹ️ Element benutzt standardmäßig die Ende-zu-Ende-Verschlüsselung.
 
-ℹ️ Trotz Verschlüsselung fallen bei Matrix Metadaten an. Beachte die [Hinweise zur sicheren Nutzung](https://wiki.systemli.org/howto/matrix-privacy) in unserem Wiki.
+ℹ️ Trotz Verschlüsselung fallen bei Matrix Metadaten an. Beachte die [Hinweise zur sicheren Nutzung](https://wiki.systemli.org/howto/matrix/privacy) in unserem Wiki.
 
 ℹ️ Neben den von uns empfohlenen Client Element gibt es weitere Clients für Matrix. Dabei kann es vor kommen, dass 
 diese nicht alle Features (auch sicherheitsrelevante) eingebaut haben. Du solltest dir die 
-[Features genau ansehen](https://matrix.org/clients-matrix/) und abwägen welchen Client du benutzt.
+[Features genau ansehen](https://matrix.org/ecosystem/clients/) und abwägen welchen Client du benutzt.


### PR DESCRIPTION
There were some dead URLs in the German and English matrix.md that are fixed now.